### PR TITLE
Differentiate between a failure response and an intentionally null response

### DIFF
--- a/src/Amqp.php
+++ b/src/Amqp.php
@@ -174,7 +174,7 @@ class Amqp
      */
     public function requestWithResponse(string $route, string $message, array $properties = []): ?string
     {
-        $response = null;
+        $response = false;
         $this->request(
             $route,
             [$message],
@@ -183,7 +183,12 @@ class Amqp
             },
             $properties,
         );
-        return $response;
+        // If $response is still false, it means no message was received (timeout/failure)
+        // If $response is null, it means a message was received with no body (valid)
+        if ($response === false) {
+            return null; // true failure
+        }
+        return $response ?? ''; // empty string for valid empty response
     }
 
     /**

--- a/tests/Unit/AmqpTest.php
+++ b/tests/Unit/AmqpTest.php
@@ -248,6 +248,70 @@ class AmqpTest extends BaseTest
         ));
     }
 
+    public function testRequestWithResponseHandlerWithEmptyResponse()
+    {
+        $response = '';
+        $route = 'example.route.3';
+        $message = 'message3';
+        $mockedResponseMessage = Mockery::mock('PhpAmqpLib\Message\AMQPMessage[getBody]');
+        $mockedResponseMessage->shouldReceive('getBody')->once()->andReturn($response);
+        $mockedFacade = Mockery::mock('ComLaude\Amqp\Amqp[request]');
+        $mockedFacade->shouldReceive('request')->once()->with(
+            $route,
+            [$message],
+            Mockery::any(),
+            [],
+        )->andReturnUsing(function ($route, $messages, $callback, $properties) use ($mockedResponseMessage) {
+            $callback($mockedResponseMessage);
+            return true;
+        });
+        $this->assertEquals($response, $mockedFacade->requestWithResponse(
+            $route,
+            $message
+        ));
+    }
+
+    public function testRequestWithResponseHandlerWithNullResponse()
+    {
+        $route = 'example.route.3';
+        $message = 'message3';
+        $mockedResponseMessage = Mockery::mock('PhpAmqpLib\Message\AMQPMessage[getBody]');
+        $mockedResponseMessage->shouldReceive('getBody')->once()->andReturnNull();
+        $mockedFacade = Mockery::mock('ComLaude\Amqp\Amqp[request]');
+        $mockedFacade->shouldReceive('request')->once()->with(
+            $route,
+            [$message],
+            Mockery::any(),
+            [],
+        )->andReturnUsing(function ($route, $messages, $callback, $properties) use ($mockedResponseMessage) {
+            $callback($mockedResponseMessage);
+            return true;
+        });
+        $this->assertEquals('', $mockedFacade->requestWithResponse(
+            $route,
+            $message
+        ));
+    }
+
+    public function testRequestWithResponseHandlerWithTimeout()
+    {
+        $route = 'example.route.3';
+        $message = 'message3';
+        $mockedResponseMessage = Mockery::mock('PhpAmqpLib\Message\AMQPMessage[getBody]');
+        $mockedResponseMessage->shouldReceive('getBody')->never();
+        $mockedFacade = Mockery::mock('ComLaude\Amqp\Amqp[request]');
+        $mockedFacade->shouldReceive('request')->once()->with(
+            $route,
+            [$message],
+            Mockery::any(),
+            [],
+        )->andReturnFalse();
+        $this->assertEquals(null, $mockedFacade->requestWithResponse(
+            $route,
+            $message
+        ));
+    }
+
     public function testCount()
     {
         $mockedFacade = new Amqp;


### PR DESCRIPTION
When using this library, it's possible to trigger one-way messages, i.e. messages where there is no intended response (example: using it to trigger an API call where there is no response body).

Currently, when using the `requestWithResponse` method:
- If there is *no* intended response, we return null.
- If there is an intended response, but the process timed out or failed in some way, we return null.

With this PR, when using the `requestWithResponse` method:
- If there is *no* intended response, we return an empty string.
- If there is an intended response, but the process timed out or failed in some way, we return null.

This way, the current process of returning null in the event of a failure remains functional, but if there is an empty response (i.e. the message did return successfully, but without a body), then we can recognise the difference when we're using this method.